### PR TITLE
fix: 修复右下角[节点打码],[坐标生成]图标不显示的问题

### DIFF
--- a/src/common/insertIcon.ts
+++ b/src/common/insertIcon.ts
@@ -70,7 +70,9 @@ observeElement(
 );
 
 observeElement('#iconBar', () => {
-  const app = document.querySelector('#app')!;
+  // const app = document.querySelector('#app')!;
+  // 查找新的根元素（网站把 #app 改成了 body 的最后一个 div）
+  const app = document.querySelector('body > div:last-child') || document.body;
 
   // 节点打码按钮
   const editNodeIcon = document.createElement('mdui-fab');


### PR DESCRIPTION
由于GKD 网页端审查工具更新（[Commit 38e9172](https://github.com/gkd-kit/inspect/commit/38e9172)），将root.ts中的根元素创建改为向body添加一个新的div，导致脚本取不到`#app`的值。。。。。

<img width="824" height="235" alt="image" src="https://github.com/user-attachments/assets/5411c0c2-1caf-49c9-b24b-d237f687e2cf" />


